### PR TITLE
ENode integration part 2.

### DIFF
--- a/ethp2p.nim
+++ b/ethp2p.nim
@@ -8,6 +8,5 @@
 #            MIT license (LICENSE-MIT)
 #
 
-import ethp2p/[ecies, auth, hexdump, enode, rlpxcrypt, discovery, kademlia,
-               rlpx]
-export ecies, auth, enode, hexdump, rlpxcrypt, discovery, kademlia, rlpx
+import ethp2p/[ecies, auth, hexdump, enode, rlpxcrypt, discovery, kademlia]
+export ecies, auth, enode, hexdump, rlpxcrypt, discovery, kademlia

--- a/ethp2p.nim
+++ b/ethp2p.nim
@@ -8,5 +8,6 @@
 #            MIT license (LICENSE-MIT)
 #
 
-import ethp2p/ecies, ethp2p/auth, ethp2p/hexdump, ethp2p/enode
-export ecies, auth, enode, hexdump
+import ethp2p/[ecies, auth, hexdump, enode, rlpxcrypt, discovery, kademlia,
+               rlpx]
+export ecies, auth, enode, hexdump, rlpxcrypt, discovery, kademlia, rlpx

--- a/ethp2p/discovery.nim
+++ b/ethp2p/discovery.nim
@@ -162,7 +162,7 @@ proc sendNeighbours*(d: DiscoveryProtocol, node: Node, neighbours: seq[Node]) =
 
   if nodes.len != 0: flush()
 
-proc newDiscoveryProtocol*(privKey: PrivateKey, address: Address, bootstrapNodes: openarray[string]): DiscoveryProtocol =
+proc newDiscoveryProtocol*(privKey: PrivateKey, address: Address, bootstrapNodes: openarray[ENode]): DiscoveryProtocol =
   result.new()
   result.privKey = privKey
   result.address = address
@@ -312,12 +312,16 @@ when isMainModule:
   #   let (remotePubkey, cmdId, payload) = unpack(m)
   #   assert(remotePubkey.raw_key.toHex == privKey.public_key.raw_key.toHex)
 
+  var bootnodes = newSeq[ENode]()
+  for item in LOCAL_BOOTNODES:
+    bootnodes.add(initENode(item))
+
   let listenPort = Port(30310)
   var address = Address(udpPort: listenPort, tcpPort: listenPort)
   address.ip.family = IpAddressFamily.IPv4
-  let discovery = newDiscoveryProtocol(privkey, address, LOCAL_BOOTNODES)
+  let discovery = newDiscoveryProtocol(privkey, address, bootnodes)
 
-  echo discovery.thisNode.pubkey
+  echo discovery.thisNode.node.pubkey
   echo "this_node.id: ", discovery.thisNode.id.toHex()
 
   discovery.open()

--- a/ethp2p/kademlia.nim
+++ b/ethp2p/kademlia.nim
@@ -61,6 +61,11 @@ proc newNode*(uriString: string): Node =
   result.node = initENode(uriString)
   result.id = result.node.pubkey.toNodeId()
 
+proc newNode*(enode: ENode): Node =
+  result.new()
+  result.node = enode
+  result.id = result.node.pubkey.toNodeId()
+
 proc distanceTo(n: Node, id: NodeId): UInt256 = n.id xor id
 
 proc `$`*(n: Node): string =


### PR DESCRIPTION
- Add newNode(ENode).
- Change newDiscoveryProtocol to use not strings, but ENode.