### PR TITLE
Update test proc

### DIFF
--- a/ethp2p.nimble
+++ b/ethp2p.nimble
@@ -16,11 +16,19 @@ requires "nim > 0.18.0",
          "https://github.com/status-im/nim-stint",
          "https://github.com/status-im/nim-byteutils"
 
-proc runTest(name: string, lang = "c") = exec "nim " & lang & " -r tests/" & name
+proc runTest(name: string, lang = "c") =
+  if not dirExists "build":
+    mkDir "build"
+  if not dirExists "nimcache":
+    mkDir "nimcache"
+  --run
+  --nimcache: "nimcache"
+  switch("out", ("./build/" & name))
+  setCommand lang, "tests/" & name & ".nim"
 
 task test, "Runs the test suite":
   runTest "testecies"
   runTest "testauth"
   runTest "testcrypt"
   runTest "testenode"
-  runTest("tdiscovery", "cpp")
+  runTest "tdiscovery"


### PR DESCRIPTION
- tdiscovery now compiles with C by default instead of C++
- Tests now use nim-eth-p2p/nimcache instead of nim-eth-p2p/tests/nimcache
- Tests now put binaries in nim-eth-p2p/build instead of nim-eth-p2p/tests
- Instead of spawning a new instance of nim for each tests (`exec`) it reuses the same Nim instance (`setCommand`) which should be faster.