### PR TITLE
Proper sync part 1

### DIFF
--- a/eth_p2p/kademlia.nim
+++ b/eth_p2p/kademlia.nim
@@ -67,6 +67,7 @@ proc newNode*(enode: ENode): Node =
 proc distanceTo(n: Node, id: NodeId): UInt256 = n.id xor id
 
 proc `$`*(n: Node): string =
+  # "Node[" & $n.node & "]"
   "Node[" & $n.node.address.ip & ":" & $n.node.address.udpPort & "]"
 
 proc hash*(n: Node): hashes.Hash = hash(n.node.pubkey.data)
@@ -478,6 +479,8 @@ proc randomNodes*(k: KademliaProtocol, count: int): seq[Node] =
       if node notin seen:
         result.add(node)
         seen.incl(node)
+
+proc nodesDiscovered*(k: KademliaProtocol): int {.inline.} = k.routing.len
 
 when isMainModule:
   proc randomNode(): Node =


### PR DESCRIPTION
Part 1 of proper sync:
- PeerPool observation. Technically SyncCtx can now be created at any moment with potentially empty peerpool. It will watch for new peers, and will start syncing with them as they arrive.
- Added "trusted sync peers" logic, which should block syncing until it finds a group of peers that all agree to each other that they are on the same chain.
- Changed eth handshake to raise if networkId/genesis don't match, to not let them into PeerPool.

Still TODO:
- <s>Proper ordering of downloaded blocks to feed to state reconstruction</s>
- Error reporting from state reconstruction to block downloader to readjust "trusted" peer set.
