### PR TITLE
Fix import of shh_protocol in tshh test

### DIFF
--- a/tests/tshh.nim
+++ b/tests/tshh.nim
@@ -11,7 +11,7 @@ import
   sequtils, options, unittest,
   nimcrypto/hash,
   eth_keys, rlp,
-  eth_p2p/rlpx_protocols/shh
+  eth_p2p/rlpx_protocols/shh_protocol as shh
 
 suite "Whisper payload":
   test "should roundtrip without keys":


### PR DESCRIPTION
Noticed that the `shh` file got renamed to `shh_protocol` after merging from wip-whisper branch(https://github.com/status-im/nim-eth-p2p/commit/8b4bbd29af3f2911b4f5786420b850f3f20a9686). Test was however not updated.

Perhaps the tshh test should be added in nimble file?

Side note: I also noticed that this commit was never merged from the wip-whisper branch: https://github.com/status-im/nim-eth-p2p/commit/ee4fc12f4605cbcee84748e2e628a576e6b2b3e4