### PR TITLE
Resolving several connection issues

### DIFF
--- a/eth_p2p.nim
+++ b/eth_p2p.nim
@@ -58,14 +58,15 @@ proc processIncoming(server: StreamServer,
   yield peerfut
   if not peerfut.failed:
     let peer = peerfut.read()
-    if peer.remote notin node.peerPool.connectedNodes:
-      node.peerPool.connectedNodes[peer.remote] = peer
-      for o in node.peerPool.observers.values:
-        if not o.onPeerConnected.isNil:
-          o.onPeerConnected(peer)
-    else:
-      debug "Disconnecting already connected node"
-      await peer.disconnect(AlreadyConnected)
+    if node.peerPool != nil:
+      if peer.remote notin node.peerPool.connectedNodes:
+        node.peerPool.connectedNodes[peer.remote] = peer
+        for o in node.peerPool.observers.values:
+          if not o.onPeerConnected.isNil:
+            o.onPeerConnected(peer)
+      else:
+        debug "Disconnecting already connected node"
+        await peer.disconnect(AlreadyConnected)
   else:
     remote.close()
 

--- a/eth_p2p.nim
+++ b/eth_p2p.nim
@@ -59,13 +59,10 @@ proc processIncoming(server: StreamServer,
   if not peerfut.failed:
     let peer = peerfut.read()
     if node.peerPool != nil:
-      if peer.remote notin node.peerPool.connectedNodes:
-        node.peerPool.connectedNodes[peer.remote] = peer
-        for o in node.peerPool.observers.values:
-          if not o.onPeerConnected.isNil:
-            o.onPeerConnected(peer)
-      else:
-        debug "Disconnecting already connected node"
+      if not node.peerPool.addPeer(peer):
+        # In case an outgoing connection was added in the meanwhile or a
+        # malicious peer opens multiple connections
+        debug "Disconnecting peer (incoming)", reason = AlreadyConnected
         await peer.disconnect(AlreadyConnected)
   else:
     remote.close()

--- a/eth_p2p/rlpx.nim
+++ b/eth_p2p/rlpx.nim
@@ -1108,6 +1108,10 @@ rlpxProtocol p2p(version = 0):
     discard
 
 proc removePeer(network: EthereumNode, peer: Peer) =
+  # It is necessary to check if peer.remote still exists. The connection might
+  # have been dropped already from the peers side.
+  # E.g. when receiving a p2p.disconnect message from a peer, a race will happen
+  # between which side disconnects first.
   if network.peerPool != nil and not peer.remote.isNil:
     network.peerPool.connectedNodes.del(peer.remote)
 


### PR DESCRIPTION
Should resolve issues I encountered while working on and testing whisper.

- Adding peers to peer pool on incoming connection
- Exclude bootnodes from nodes to connect to:
Perhaps not really an issue, but rather an annoyance and unnecessary. I still left the code in there that tries to connect to a random bootnode in case of 0 connections.
- Check if peer is already connected to before adding to peer pool:
Only 1 connection allowed per peer, also important in case of race of incoming versus outgoing connection with same peer.
- Check if peer is still connected to before removing from peer pool: Without this there is a segfault possible since recently this line was added: https://github.com/status-im/nim-eth-p2p/blob/master/eth_p2p/rlpx.nim#L485 (race of the peer disconnecting you versus you disconnecting the peer). 