### PR TITLE
don't swallow random exceptions

### DIFF
--- a/eth_p2p/rlpx.nim
+++ b/eth_p2p/rlpx.nim
@@ -1352,9 +1352,11 @@ proc rlpxConnect*(node: EthereumNode, remote: Node): Future[Peer] {.async.} =
   except TransportOsError:
     trace "TransportOsError", err = getCurrentExceptionMsg()
   except:
+    let e = getCurrentException()
     debug "Exception in rlpxConnect", remote,
-          exc = getCurrentException().name,
+          exc = e.name,
           err = getCurrentExceptionMsg()
+    raise e
 
   if not ok:
     if not isNil(result.transport):


### PR DESCRIPTION
this hides bugs, like this one:

```
DBG 2018-12-26 08:48:15-06:00 Exception in rlpxConnect                   topics="rlpx" thread=0 err="Future still in progress.\nAsync traceback:\n  cligen.nim(797)           status_chat\n  cligen.nim(552)           dispatchstatusListener\n  status_chat.nim(112)      statusListener\n  asyncloop.nim(238)        poll\n  asyncmacro2.nim(36)       handshakeImpl_continue\n  rlpx.nim(1158)            handshakeImplIter\n  asyncfutures2.nim(330)    read\n  #[\n    cligen.nim(797)           status_chat\n    cligen.nim(552)           dispatchstatusListener\n    status_chat.nim(112)      statusListener\n    asyncloop.nim(238)        poll\n    asyncmacro2.nim(36)       WhisperHandshake_continue\n    whisper_protocol.nim(695) WhisperHandshakeIter\n    asyncfutures2.nim(325)    read\n  ]#\n  #[\n    cligen.nim(797)           status_chat\n    cligen.nim(552)           dispatchstatusListener\n    status_chat.nim(112)      statusListener\n    asyncloop.nim(238)        poll\n    asyncmacro2.nim(36)       postHelloSteps_continue\n    rlpx.nim(1245)            postHelloStepsIter\n    asyncfutures2.nim(325)    read\n  ]#\nException message: Future still in progress.\nException type:" exc=ValueError remote=Node[54.238.158.169:30303]
```