### PR TITLE
Fixed out of range error in randomPeerWith

### DIFF
--- a/eth_p2p.nim
+++ b/eth_p2p.nim
@@ -159,5 +159,5 @@ proc randomPeerWith*(node: EthereumNode, Protocol: type): Peer =
   for p in node.peers(Protocol):
     candidates.add(p)
   if candidates.len > 0:
-    return candidates[rand(candidates.len)]
+    return candidates.rand()
 


### PR DESCRIPTION
`rand(a: int)` can return `a` in which case we're getting out of bounds error.